### PR TITLE
壁走りできる問題の修正

### DIFF
--- a/GravityWall/Assets/Prefabs/Player/PlayerObjects.prefab
+++ b/GravityWall/Assets/Prefabs/Player/PlayerObjects.prefab
@@ -463,6 +463,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2773374917998683312, guid: 66e11150f66154c4ebbd9178fedceadf,
         type: 3}
+      propertyPath: allowJumpDistance
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2773374917998683312, guid: 66e11150f66154c4ebbd9178fedceadf,
+        type: 3}
       propertyPath: allowJumpInterval
       value: 0.1
       objectReference: {fileID: 0}

--- a/GravityWall/Assets/Scenes/TestLevel/Playground.unity
+++ b/GravityWall/Assets/Scenes/TestLevel/Playground.unity
@@ -3930,6 +3930,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3863569561677538650, guid: b6b770b68bfd72b4c8009472cba1842e,
         type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3863569561677538650, guid: b6b770b68bfd72b4c8009472cba1842e,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.70648646
       objectReference: {fileID: 0}
@@ -3940,8 +3945,28 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3863569561677538650, guid: b6b770b68bfd72b4c8009472cba1842e,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9998411
+      objectReference: {fileID: 0}
+    - target: {fileID: 3863569561677538650, guid: b6b770b68bfd72b4c8009472cba1842e,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0.017829549
+      objectReference: {fileID: 0}
+    - target: {fileID: 3863569561677538650, guid: b6b770b68bfd72b4c8009472cba1842e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3863569561677538650, guid: b6b770b68bfd72b4c8009472cba1842e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4984162288576153998, guid: b6b770b68bfd72b4c8009472cba1842e,
+        type: 3}
+      propertyPath: allowJumpDistance
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: 5863071365648989382, guid: b6b770b68bfd72b4c8009472cba1842e,
         type: 3}
@@ -3955,6 +3980,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5979203719876794136, guid: b6b770b68bfd72b4c8009472cba1842e,
         type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5979203719876794136, guid: b6b770b68bfd72b4c8009472cba1842e,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0.70648646
       objectReference: {fileID: 0}
@@ -3965,8 +3995,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5979203719876794136, guid: b6b770b68bfd72b4c8009472cba1842e,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9998411
+      objectReference: {fileID: 0}
+    - target: {fileID: 5979203719876794136, guid: b6b770b68bfd72b4c8009472cba1842e,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0.017829549
+      objectReference: {fileID: 0}
+    - target: {fileID: 5979203719876794136, guid: b6b770b68bfd72b4c8009472cba1842e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5979203719876794136, guid: b6b770b68bfd72b4c8009472cba1842e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 6224190170551648035, guid: b6b770b68bfd72b4c8009472cba1842e,
         type: 3}

--- a/GravityWall/ProjectSettings/DynamicsManager.asset
+++ b/GravityWall/ProjectSettings/DynamicsManager.asset
@@ -10,11 +10,11 @@ PhysicsManager:
   m_DefaultMaxDepenetrationVelocity: 10
   m_SleepThreshold: 0.005
   m_DefaultContactOffset: 0.001
-  m_DefaultSolverIterations: 4
-  m_DefaultSolverVelocityIterations: 1
+  m_DefaultSolverIterations: 6
+  m_DefaultSolverVelocityIterations: 2
   m_QueriesHitBackfaces: 0
   m_QueriesHitTriggers: 1
-  m_EnableAdaptiveForce: 1
+  m_EnableAdaptiveForce: 0
   m_ClothInterCollisionDistance: 0.1
   m_ClothInterCollisionStiffness: 0.2
   m_ContactsGeneration: 1

--- a/GravityWall/ProjectSettings/EditorBuildSettings.asset
+++ b/GravityWall/ProjectSettings/EditorBuildSettings.asset
@@ -21,6 +21,9 @@ EditorBuildSettings:
     path: Assets/Scenes/Level/Hole-in.unity
     guid: 76dad554179604811aefeaf739ba4d7c
   - enabled: 1
+    path: Assets/Scenes/Level/Playground.unity
+    guid: 0e71d90b1d164e649ab6a0e2ad7a16a2
+  - enabled: 1
     path: Assets/Scenes/Level/Root.unity
     guid: 29d3a10066b403541a1556ee90c5ee28
   - enabled: 1


### PR DESCRIPTION
以下の問題を修正しました。
・壁変更能力がない状態での壁張り付き
→この状態でジャンプ連打すると壁走りができてしまう。

・床と壁が異なるコライダで構成されている場所で、壁張り付き
→この状態でジャンプするとジャンプ力が落ちてしまう